### PR TITLE
fix nth-child implementation

### DIFF
--- a/phpQuery/phpQuery/phpQueryObject.php
+++ b/phpQuery/phpQuery/phpQueryObject.php
@@ -1052,18 +1052,20 @@ class phpQueryObject
 								return null;'),
 						new CallbackParam(), $param
 					);
-				else if (mb_strlen($param) > 1 && $param{1} == 'n')
+				else if (mb_strlen($param) > 1 && preg_match('/^(\d*)n([-+]?)(\d*)/', $param) === 1)
 					// an+b
 					$mapped = $this->map(
 						create_function('$node, $param',
 							'$prevs = pq($node)->prevAll()->size();
 							$index = 1+$prevs;
-							$b = mb_strlen($param) > 3
-								? $param{3}
-								: 0;
-							$a = $param{0};
-							if ($b && $param{2} == "-")
-								$b = -$b;
+
+							preg_match("/^(\d*)n([-+]?)(\d*)/", $param, $matches);
+							$a = intval($matches[1]);
+							$b = intval($matches[3]);
+							if( $matches[2] === "-" ) {
+							    $b = -$b;
+							}
+
 							if ($a > 0) {
 								return ($index-$b)%$a == 0
 									? $node


### PR DESCRIPTION
The previous nth-child('an+b') implementation could only have a and b values that were single digit (eg
 5n-7).  Patterns like 13n+14 were not supported, and were interpreted as nth-child('13').
