### PR TITLE
Replace deprecated functions split() and join() with explode() and implode().

### DIFF
--- a/phpQuery/phpQuery/phpQueryObject.php
+++ b/phpQuery/phpQuery/phpQueryObject.php
@@ -3101,7 +3101,7 @@ class phpQueryObject
 					: "{$node->tagName}[{$i}]";
 				$node = $node->parentNode;
 			}
-			$xpath = join('/', array_reverse($xpath));
+			$xpath = implode('/', array_reverse($xpath));
 			$return[] = '/'.$xpath;
 		}
 		return $oneNode
@@ -3123,7 +3123,7 @@ class phpQueryObject
 					.($node->getAttribute('id')
 						? '#'.$node->getAttribute('id'):'')
 					.($node->getAttribute('class')
-						? '.'.join('.', split(' ', $node->getAttribute('class'))):'')
+						? '.'.implode('.', explode(' ', $node->getAttribute('class'))):'')
 					.($node->getAttribute('name')
 						? '[name="'.$node->getAttribute('name').'"]':'')
 					.($node->getAttribute('value') && strpos($node->getAttribute('value'), '<'.'?php') === false


### PR DESCRIPTION
Hey man,

Here's a pretty safe change to replace some deprecated functions. Appreciate it if you can merge it in. Cheers.