### PR TITLE
Change homepage to https://github.com/electrolinux/phpquery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,16 +7,19 @@
     ,"homepage": "http://code.google.com/p/phpquery/"
     ,"license": "MIT"
     ,"authors": [
-        {
+
+         {
+             "name": "didier Belot"
+             ,"role": "Packager"
+             ,"homepage": "https://github.com/electrolinux/phpquery"
+        }
+        ,{
             "name": "Tobiasz Cudnik"
             ,"email": "tobiasz.cudnik@gmail.com"
             ,"homepage": "https://github.com/TobiaszCudnik"
             ,"role": "Developer"
         }
-        ,{
-            "name": "didier Belot"
-            ,"role": "Packager"
-        }
+
     ],
     "autoload": {
         "classmap": ["phpQuery/"]


### PR DESCRIPTION
From what I can tell this is the location of the active fork & pointing to the other repo is confusing